### PR TITLE
Implement hybrid approach for API handling

### DIFF
--- a/BMSwift/Sources/BMSwift/Features/Auth/ViewModels/EncyclopediaViewModel.swift
+++ b/BMSwift/Sources/BMSwift/Features/Auth/ViewModels/EncyclopediaViewModel.swift
@@ -7,7 +7,7 @@ public class EncyclopediaViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var error: Error?
     
-    private let apiService = APIService.shared
+    private let apiService = EncyclopediaAPIService.shared
     
     public init() {}
     

--- a/BMSwift/Sources/BMSwift/Features/Auth/ViewModels/ForgotPasswordViewModel.swift
+++ b/BMSwift/Sources/BMSwift/Features/Auth/ViewModels/ForgotPasswordViewModel.swift
@@ -10,7 +10,7 @@ public class ForgotPasswordViewModel: ObservableObject {
     @Published public var errorMessage: String?
     @Published public var successMessage: String?
     
-    private let apiService = APIService.shared
+    private let apiService = AuthAPIService.shared
     
     public init() {}
     

--- a/BMSwift/Sources/BMSwift/Features/Auth/ViewModels/LoginViewModel.swift
+++ b/BMSwift/Sources/BMSwift/Features/Auth/ViewModels/LoginViewModel.swift
@@ -12,7 +12,7 @@ public class LoginViewModel: ObservableObject {
     @Published var showPasswordWarning = false
     @Published private(set) var token: String?
     
-    private let apiService = APIService.shared
+    private let apiService = AuthAPIService.shared
     private let tokenManager = TokenManager.shared
     
     public init() {

--- a/BMSwift/Sources/BMSwift/Features/Auth/ViewModels/RegisterViewModel.swift
+++ b/BMSwift/Sources/BMSwift/Features/Auth/ViewModels/RegisterViewModel.swift
@@ -15,7 +15,7 @@ class RegisterViewModel: ObservableObject {
     @Published var isRegistered = false
     @Published var showPasswordWarning = false
     
-    private let apiService = APIService.shared
+    private let apiService = AuthAPIService.shared
     
     func register() async {
         isLoading = true

--- a/BMSwift/Sources/BMSwift/Services/Network/AuthAPIService.swift
+++ b/BMSwift/Sources/BMSwift/Services/Network/AuthAPIService.swift
@@ -58,75 +58,6 @@ public struct ErrorResponse: Codable {
     }
 }
 
-// MARK: - Encyclopedia Models
-public struct FrontPageContent: Codable {
-    let hotContents: [ArticlePreview]
-    let latestContents: [ArticlePreview]
-}
-
-public struct ArticlePreview: Codable, Identifiable {
-    public var id: Int { bp_subsection_id }
-    let bp_subsection_id: Int
-    let bp_subsection_title: String
-    let bp_subsection_intro: String
-    let media_name: String
-    let visit: Int
-    let likecount: Int
-    let platform: Int
-    let clientlike: Int
-    let clientvisit: Int
-    let clientkeep: Int
-}
-
-public struct ArticleDetail: Codable {
-    let info: ArticleInfo
-    let cnt: [ArticleContent]
-    let keywords: [Keyword]
-    let suggests: [ArticleSuggestion]
-    let chapters: [Chapter]
-    let clientsAction: ClientActions
-}
-
-public struct ArticleInfo: Codable {
-    let bp_subsection_id: Int
-    let bp_subsection_title: String
-    let platform: Int
-    let bp_subsection_intro: String
-    let name: String
-    let bp_subsection_state: Int
-    let visit: Int
-    let bp_subsection_first_enabled_at: String
-    let likecount: Int
-}
-
-public struct ArticleContent: Codable {
-    let type: Int
-    let title: String
-    let cnt: String
-}
-
-public struct Keyword: Codable {
-    let bp_hashtag: String
-    let bp_tag_id: Int
-}
-
-public struct ArticleSuggestion: Codable {
-    let bp_subsection_id: Int
-    let bp_subsection_title: String
-    let bp_subsection_intro: String
-    let name: String
-}
-
-public struct Chapter: Codable {
-    let bp_chapter_id: Int
-    let bp_chapter_name: String
-}
-
-public struct ClientActions: Codable {
-    let keep: Bool
-    let like: Bool
-}
-
 // MARK: - Network Error
 public enum APIError: LocalizedError {
     case invalidURL
@@ -157,10 +88,10 @@ public enum APIError: LocalizedError {
     }
 }
 
-// MARK: - API Service
-public class APIService {
+// MARK: - Auth API Service
+public class AuthAPIService {
     private let baseURL = "https://wiki.kinglyrobot.com/api"
-    public static let shared = APIService()
+    public static let shared = AuthAPIService()
     
     private init() {}
     
@@ -169,12 +100,6 @@ public class APIService {
         static let login = "/login"
         static let register = "/register"
         static let forgotPassword = "/forgot-password"
-    }
-    
-    // MARK: - Encyclopedia Endpoints
-    private enum EncyclopediaEndpoint {
-        static let frontPageContent = "/beauty/frontPageContent"
-        static let articleDetail = "/pageContentArticle/"  // Append article ID
     }
     
     // MARK: - Authentication Methods
@@ -201,23 +126,6 @@ public class APIService {
     public func logout() {
         // Clear any stored tokens or user data
         // Add token clearing logic here if needed
-    }
-    
-    // MARK: - Encyclopedia Methods
-    public func getFrontPageContent(token: String) async throws -> FrontPageContent {
-        return try await makeRequest(
-            EncyclopediaEndpoint.frontPageContent,
-            method: "GET",
-            token: token
-        )
-    }
-    
-    public func getArticleDetail(id: Int, token: String) async throws -> ArticleDetail {
-        return try await makeRequest(
-            EncyclopediaEndpoint.articleDetail + "\(id)",
-            method: "GET",
-            token: token
-        )
     }
     
     private func makeRequest<T: Codable>(_ endpoint: String,

--- a/BMSwift/Sources/BMSwift/Services/Network/EncyclopediaAPIService.swift
+++ b/BMSwift/Sources/BMSwift/Services/Network/EncyclopediaAPIService.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public class EncyclopediaAPIService: APIService {
+    public static let shared = EncyclopediaAPIService()
+    
+    private override init() {
+        super.init()
+    }
+    
+    public func getFrontPageContent(token: String) async throws -> FrontPageContent {
+        return try await makeRequest(
+            "/beauty/frontPageContent",
+            method: "GET",
+            token: token
+        )
+    }
+    
+    public func getArticleDetail(id: Int, token: String) async throws -> ArticleDetail {
+        return try await makeRequest(
+            "/pageContentArticle/\(id)",
+            method: "GET",
+            token: token
+        )
+    }
+}

--- a/BMSwift/Sources/BMSwift/Services/Network/NLUAPIService.swift
+++ b/BMSwift/Sources/BMSwift/Services/Network/NLUAPIService.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+public class NLUAPIService: APIService {
+    public static let shared = NLUAPIService()
+    
+    private override init() {
+        super.init()
+    }
+    
+    // MARK: - NLU Endpoints
+    private enum NLUEndpoint {
+        static let analyzeText = "/nlu/analyzeText"
+        static let getResponse = "/nlu/getResponse"
+    }
+    
+    // MARK: - NLU Methods
+    public func analyzeText(text: String, token: String) async throws -> [String: Any] {
+        let url = URL(string: "\(baseURL)\(NLUEndpoint.analyzeText)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let body: [String: Any] = ["text": text]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        
+        switch httpResponse.statusCode {
+        case 200:
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: [])
+                guard let result = json as? [String: Any] else {
+                    throw APIError.decodingError
+                }
+                return result
+            } catch {
+                throw APIError.decodingError
+            }
+        case 401:
+            throw APIError.unauthorized
+        default:
+            throw APIError.serverError(httpResponse.statusCode)
+        }
+    }
+    
+    public func getResponse(for text: String, token: String) async throws -> String {
+        let url = URL(string: "\(baseURL)\(NLUEndpoint.getResponse)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let body: [String: Any] = ["text": text]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        
+        switch httpResponse.statusCode {
+        case 200:
+            guard let result = String(data: data, encoding: .utf8) else {
+                throw APIError.decodingError
+            }
+            return result
+        case 401:
+            throw APIError.unauthorized
+        default:
+            throw APIError.serverError(httpResponse.statusCode)
+        }
+    }
+}

--- a/BMSwift/Sources/BMSwift/Services/Network/SkinAnalyzeAPIService.swift
+++ b/BMSwift/Sources/BMSwift/Services/Network/SkinAnalyzeAPIService.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+public class SkinAnalyzeAPIService: APIService {
+    public static let shared = SkinAnalyzeAPIService()
+    
+    private override init() {
+        super.init()
+    }
+    
+    // MARK: - Skin Analysis Endpoints
+    private enum SkinAnalyzeEndpoint {
+        static let analyze = "/skin/analyze"
+        static let results = "/skin/results"
+    }
+    
+    // MARK: - Skin Analysis Methods
+    public func uploadImage(imageData: Data, token: String) async throws -> String {
+        let url = URL(string: "\(baseURL)\(SkinAnalyzeEndpoint.analyze)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.httpBody = imageData
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        
+        switch httpResponse.statusCode {
+        case 200:
+            guard let result = String(data: data, encoding: .utf8) else {
+                throw APIError.decodingError
+            }
+            return result
+        case 401:
+            throw APIError.unauthorized
+        default:
+            throw APIError.serverError(httpResponse.statusCode)
+        }
+    }
+    
+    public func getAnalysisResults(token: String) async throws -> [String: Any] {
+        let url = URL(string: "\(baseURL)\(SkinAnalyzeEndpoint.results)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        
+        switch httpResponse.statusCode {
+        case 200:
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: [])
+                guard let result = json as? [String: Any] else {
+                    throw APIError.decodingError
+                }
+                return result
+            } catch {
+                throw APIError.decodingError
+            }
+        case 401:
+            throw APIError.unauthorized
+        default:
+            throw APIError.serverError(httpResponse.statusCode)
+        }
+    }
+}


### PR DESCRIPTION
Restructure API handling to use a hybrid approach with centralized and feature-specific services.

* **Rename and Update AuthAPIService**
  - Rename `APIService` to `AuthAPIService` in `BMSwift/Sources/BMSwift/Services/Network/AuthAPIService.swift`.
  - Remove encyclopedia-related methods from `AuthAPIService`.
  - Update references in `LoginViewModel`, `RegisterViewModel`, and `ForgotPasswordViewModel` to use `AuthAPIService`.

* **Add SkinAnalyzeAPIService**
  - Create `SkinAnalyzeAPIService` class extending `APIService` in `BMSwift/Sources/BMSwift/Services/Network/SkinAnalyzeAPIService.swift`.
  - Add methods for skin analysis API requests, including uploading images and retrieving analysis results.

* **Add NLUAPIService**
  - Create `NLUAPIService` class extending `APIService` in `BMSwift/Sources/BMSwift/Services/Network/NLUAPIService.swift`.
  - Add methods for NLU API requests, including analyzing text and getting responses.

* **Add EncyclopediaAPIService**
  - Create `EncyclopediaAPIService` class extending `APIService` in `BMSwift/Sources/BMSwift/Services/Network/EncyclopediaAPIService.swift`.
  - Add methods for encyclopedia API requests, including retrieving front page content and article details.
  - Update `EncyclopediaViewModel` to use `EncyclopediaAPIService`.

